### PR TITLE
Fortran install

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,2 @@
 include README.rst
-recursive-include nomad *.pyx
+recursive-include nomad *.f90

--- a/bin/nomad_driver
+++ b/bin/nomad_driver
@@ -5,7 +5,6 @@ The main nomad driver.
 import os
 import sys
 import numpy as np
-import mpi4py.MPI as MPI
 import nomad.core.glbl as glbl
 import nomad.core.files as files
 import nomad.core.log as log
@@ -22,14 +21,12 @@ def init():
     This must be separate from main so that an error which occurs
     before the input file is created will be written to stdout.
     """
-    # initialize MPI communicator
     if glbl.mpi['parallel']:
+        # initialize MPI communicator
+        import mpi4py.MPI as MPI
         glbl.mpi['comm']  = MPI.COMM_WORLD
         glbl.mpi['rank']  = glbl.mpi['comm'].Get_rank()
         glbl.mpi['nproc'] = glbl.mpi['comm'].Get_size()
-    else:
-        glbl.mpi['rank']  = 0
-        glbl.mpi['nproc'] = 1
 
     # start the global timer
     timings.start('global')

--- a/bin/nomad_extract
+++ b/bin/nomad_extract
@@ -91,7 +91,7 @@ def process_arguments(args):
     chkpt_file = args[1]
 
     if not os.path.isfile(chkpt_file):
-        exit_error('input file: '+str(ckhpt_file)+' not found')
+        raise ValueError('input file: '+str(ckhpt_file)+' not found')
 
     iarg = 2
     while iarg < len(args):

--- a/nomad/compiled/nuclear_dirac.f90
+++ b/nomad/compiled/nuclear_dirac.f90
@@ -1,11 +1,12 @@
 !
 !
-! Evaluates integrals of operators over dirac test functions
+! Evaluates integrals of operators over Dirac test functions
 !
 !
 
   !
-  !
+  ! Returns the overlap of a Dirac delta function and a primitive
+  ! Gaussian function
   !
   subroutine overlap(x1, g2, a2, x2, p2, S)
     implicit none
@@ -23,13 +24,14 @@
     prefactor = (2. * a2 / pi)**(0.25)
     real_part = a2 * dx**2 
     imag_part = p2 * dx
-    S = exp(I * g2 ) * product(prefactor) * exp(sum(-real_part + I*imag_part))
+    S = exp(I * g2) * product(prefactor) * exp(sum(-real_part + I*imag_part))
 
     return
   end subroutine overlap
 
   !
-  !
+  ! Returns the del/dp integral of a Dirac delta function and a primitive
+  ! Gaussian function
   !
   subroutine deldp(S, x1, x2, int_delp)
     implicit none
@@ -47,7 +49,8 @@
   end subroutine deldp
 
   !
-  !
+  ! Returns the del/dx integral of a Dirac delta function and a primitive
+  ! Gaussian function
   !
   subroutine deldx(S, x1, a2, x2, p2, int_delx)
     implicit none
@@ -65,8 +68,8 @@
   end subroutine deldx
 
   !
-  ! Returns the del^2/d^2x matrix element between the nuclear component
-  ! of two trajectories for each componet of 'x' (does not sum over terms)
+  ! Returns the del^2/d^2x integral of a Dirac delta function and a
+  ! primitive Gaussian function
   !
   subroutine deld2x(S, x1, a2, x2, p2, int_del2x)
     implicit none

--- a/nomad/compiled/nuclear_gaussian.f90
+++ b/nomad/compiled/nuclear_gaussian.f90
@@ -1,5 +1,11 @@
+!
+!
+! Evaluates integrals over operators of Gaussian basis functions
+!
+!
+
   !
-  !
+  ! Returns the overlap of two Gaussian basis functions
   !
   subroutine overlap(g1, a1, x1, p1, g2, a2, x2, p2, S)
     implicit none
@@ -23,7 +29,7 @@
   end subroutine overlap
 
   !
-  !
+  ! Returns the del/dp integral between two Gaussian basis functions
   !
   subroutine deldp(S, a1, x1, p1, a2, x2, p2, delp)
     implicit none
@@ -42,7 +48,7 @@
   end subroutine deldp
 
   !
-  !
+  ! Returns the del/dx integral between two Gaussian basis functions
   !
   subroutine deldx(S, a1, x1, p1, a2, x2, p2, delx)
     implicit none
@@ -61,8 +67,7 @@
   end subroutine deldx
 
   !
-  ! Returns the del^2/d^2x matrix element between the nuclear component
-  ! of two trajectories for each componet of 'x' (does not sum over terms)
+  ! Returns the del^2/d^2x integral between two Gaussian basis functions
   !
   subroutine deld2x(S, a1, x1, p1, a2, x2, p2, del2x)
     implicit none

--- a/nomad/compiled/run_f2py
+++ b/nomad/compiled/run_f2py
@@ -1,11 +1,7 @@
 #!/bin/sh
 
 rm -f *.so
-f2py3 -c --fcompiler=gfortran -m nuclear_gaussian nuclear_gaussian.f90
-f2py3 -c --fcompiler=gfortran -m nuclear_dirac nuclear_dirac.f90
-f2py3 -c --fcompiler=gfortran -m nuclear_gaussian_ccs nuclear_gaussian_ccs.f90
-f2py3 -c --fcompiler=gfortran -m vibronic_gaussian vibronic_gaussian.f90
-mv nuclear_gaussian.cpython*.so nuclear_gaussian.so
-mv nuclear_dirac.cpython*.so nuclear_dirac.so
-mv nuclear_gaussian_ccs.cpython*.so nuclear_gaussian_ccs.so
-mv vibronic_gaussian.cpython*.so vibronic_gaussian.so
+f2py -c --fcompiler=gfortran -m nuclear_gaussian nuclear_gaussian.f90
+f2py -c --fcompiler=gfortran -m nuclear_dirac nuclear_dirac.f90
+f2py -c --fcompiler=gfortran -m nuclear_gaussian_ccs nuclear_gaussian_ccs.f90
+f2py -c --fcompiler=gfortran -m vibronic_gaussian vibronic_gaussian.f90

--- a/nomad/compiled/run_f2py
+++ b/nomad/compiled/run_f2py
@@ -1,4 +1,6 @@
 #!/bin/sh
+# Compiles the nuclear integral scripts into local shared libraries.
+# This is done automatically using setup.py in the main directory.
 
 rm -f *.so
 f2py -c --fcompiler=gfortran -m nuclear_gaussian nuclear_gaussian.f90

--- a/nomad/compiled/vibronic_gaussian.f90
+++ b/nomad/compiled/vibronic_gaussian.f90
@@ -1,3 +1,9 @@
+!
+!
+! Evaluates integrals of arbitary moments of Gaussian basis functions
+!
+!
+
   !
   ! Returns the matrix element <cmplx_gaus(q,p)| q^N |cmplx_gaus(q,p)>
   !   -- up to an overlap integral --

--- a/nomad/integrals/integral.py
+++ b/nomad/integrals/integral.py
@@ -11,14 +11,8 @@ class Integral:
         self.type     = ansatz
         self.centroid = []
         self.centroid_required = []
-        try:
-            self.ints =__import__('nomad.integrals.gaussian_global', fromlist=['a'])
-        except ImportError:
-            print('Cannot import integrals: nomad.integrals.gaussian_global')
-        try:
-            self.ints_eval = __import__('nomad.integrals.'+str(self.type),fromlist=['a'])
-        except ImportError:
-            print('Cannot import integrals: nomad.integrals.'+str(self.type))
+        self.ints = __import__('nomad.integrals.gaussian_global', fromlist=['a'])
+        self.ints_eval = __import__('nomad.integrals.'+str(self.type),fromlist=['a'])
 
         self.hermitian            = self.ints.hermitian
         self.require_centroids    = self.ints_eval.require_centroids

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,9 @@
 """
 Setup script for the nomad package.
 """
-from setuptools import setup
-from setuptools.extension import Extension
 from setuptools import find_packages
-from Cython.Build import cythonize
+from numpy.distutils.core import setup
+from numpy.distutils.core import Extension
 
 
 def readme():
@@ -13,14 +12,16 @@ def readme():
         return f.read()
 
 
-ext_modules=[
-    Extension('nomad.integrals.nuclear_gaussian',
-              sources=['nomad/integrals/nuclear_gaussian.pyx'], libraries=['m']),
-    Extension('nomad.integrals.nuclear_gaussian_ccs',
-              sources=['nomad/integrals/nuclear_gaussian_ccs.pyx'], libraries=['m']),
-    Extension('nomad.integrals.nuclear_dirac',
-              sources=['nomad/integrals/nuclear_dirac.pyx'], libraries=['m'])
-             ]
+ext_modules = [
+    Extension('nomad.compiled.vibronic_gaussian',
+              sources=['nomad/compiled/vibronic_gaussian.f90']),
+    Extension('nomad.compiled.nuclear_gaussian',
+              sources=['nomad/compiled/nuclear_gaussian.f90']),
+    Extension('nomad.compiled.nuclear_gaussian_ccs',
+              sources=['nomad/compiled/nuclear_gaussian_ccs.f90']),
+    Extension('nomad.compiled.nuclear_dirac',
+              sources=['nomad/compiled/nuclear_dirac.f90'])
+               ]
 
 setup(
     name='nomad',
@@ -44,5 +45,5 @@ setup(
                  ],
     install_requires=['numpy>=1.7.0', 'scipy>=0.12.0', 'h5py>=2.5.0',
                       'mpi4py>=2.0.0'],
-    ext_modules = cythonize(ext_modules)
+    ext_modules=ext_modules
       )

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,6 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Topic :: Scientific/Engineering :: Chemistry'
                  ],
-    install_requires=['numpy>=1.7.0', 'scipy>=0.12.0', 'h5py>=2.5.0',
-                      'mpi4py>=2.0.0'],
+    install_requires=['numpy>=1.7.0', 'scipy>=0.12.0', 'h5py>=2.5.0'],
     ext_modules=ext_modules
       )


### PR DESCRIPTION
`setup.py` has been updated to automatically build the Fortran shared libraries. `mpi4py` is also now an optional package which is only imported if `nomad_driver` is called with the `-mpi` flag.